### PR TITLE
텔레그램 봇 추가, commands 구현, artifacts.rs 생성

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2021"
 
 [dependencies]
 reqwest = { version = "0.11", features = ["json"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.8", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 urlencoding = "2.1.2"
+teloxide = { version = "0.12", features = ["macros"] }
+log = "0.4"
+pretty_env_logger = "0.4"

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct ClientConfig {
+    pub seoul_url: String,
+    pub file_type: String,
+    pub service_name: String,
+    pub start_index: String,
+    pub end_index: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct RealTimeArrival {
+    subwayId: Option<String>,
+    updnLine: Option<String>,
+    trainLineNm: Option<String>,
+    statnFid: Option<String>,
+    statnTid: Option<String>,
+    statnId: Option<String>,
+    statnNm: Option<String>,
+    trnsitCo: Option<String>,
+    ordkey: Option<String>,
+    subwayList: Option<String>,
+    statnList: Option<String>,
+    btrainSttus: Option<String>,
+    barvlDt: Option<String>,
+    btrainNo: Option<String>,
+    bstatnId: Option<String>,
+    bstatnNm: Option<String>,
+    recptnDt: Option<String>,
+    arvlMsg2: Option<String>,
+    arvlMsg3: Option<String>,
+    arvlCd: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ServerMessage {
+    status: u8,
+    code: Option<String>,
+    message: Option<String>,
+    link: Option<String>,
+    developerMessage: Option<String>,
+    total: u8,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ClientResponse {
+    errorMessage: ServerMessage,
+    realtimeArrivalList: Vec<RealTimeArrival>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,74 +1,68 @@
 use std::collections::HashMap;
 use std::fs::File;
 
-use serde::{Deserialize, Serialize};
 use serde_yaml::{self};
-
+use teloxide::{prelude::*, utils::command::BotCommands};
 use urlencoding::encode;
 extern crate tokio;
 
+mod artifacts;
+use artifacts::{ClientConfig, ClientResponse};
+
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
-
-#[derive(Serialize, Deserialize)]
-struct ClientConfig {
-    seoul_url: String,
-    file_type: String,
-    service_name: String,
-    start_index: String,
-    end_index: String,
-}
-
-#[derive(Deserialize, Debug)]
-struct RealTimeArrival {
-    subwayId: Option<String>,
-    updnLine: Option<String>,
-    trainLineNm: Option<String>,
-    statnFid: Option<String>,
-    statnTid: Option<String>,
-    statnId: Option<String>,
-    statnNm: Option<String>,
-    trnsitCo: Option<String>,
-    ordkey: Option<String>,
-    subwayList: Option<String>,
-    statnList: Option<String>,
-    btrainSttus: Option<String>,
-    barvlDt: Option<String>,
-    btrainNo: Option<String>,
-    bstatnId: Option<String>,
-    bstatnNm: Option<String>,
-    recptnDt: Option<String>,
-    arvlMsg2: Option<String>,
-    arvlMsg3: Option<String>,
-    arvlCd: Option<String>,
-}
-
-#[derive(Deserialize, Debug)]
-struct ServerMessage {
-    status: u8,
-    code: Option<String>,
-    message: Option<String>,
-    link: Option<String>,
-    developerMessage: Option<String>,
-    total: u8,
-}
-
-#[derive(Deserialize, Debug)]
-struct ClientResponse {
-    errorMessage: ServerMessage,
-    realtimeArrivalList: Vec<RealTimeArrival>,
-}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // read api-key and make request url
     let api_key = get_public_api_key("src/public_subway_api_key.yml");
-    let client_config: ClientConfig = get_client_config("src/client_config.yaml");
+    let client_config: artifacts::ClientConfig = get_client_config("src/client_config.yaml");
 
     let url = make_url(api_key, client_config, "동천".to_string());
     let response = reqwest::get(url).await?.json::<ClientResponse>().await?;
 
     println!("{:?}", response);
+
+    pretty_env_logger::init();
+    log::info!("Starting command bot...");
+
+    let bot = Bot::from_env();
+
+    Command::repl(bot, answer_from_bot).await;
     return Ok(());
+}
+
+#[derive(BotCommands, Clone)]
+#[command(
+    rename_rule = "lowercase",
+    description = "These commands are supported:"
+)]
+pub enum Command {
+    #[command(description = "display this text.")]
+    Help,
+    #[command(description = "start to watch")]
+    Go(String),
+    #[command(description = "stop to watch ")]
+    Stop,
+}
+
+async fn answer_from_bot(bot: Bot, msg: Message, cmd: Command) -> ResponseResult<()> {
+    match cmd {
+        Command::Help => {
+            bot.send_message(msg.chat.id, Command::descriptions().to_string())
+                .await?
+        }
+
+        Command::Go(station) => {
+            bot.send_message(msg.chat.id, format!("watching {station}.."))
+                .await?
+        }
+        Command::Stop => {
+            bot.send_message(msg.chat.id, format!("stop to watching."))
+                .await?
+        }
+    };
+
+    Ok(())
 }
 
 fn get_public_api_key(api_key_path: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
     rename_rule = "lowercase",
     description = "These commands are supported:"
 )]
-pub enum Command {
+enum Command {
     #[command(description = "display this text.")]
     Help,
     #[command(description = "start to watch")]


### PR DESCRIPTION
## 작업 내역
- 텔레그램 봇 `teloxide` 추가
- client 관련 스트럭쳐 별개 파일(`artifacts.rs`)로 
- 기본 명령어 구현
  - 사용자가 봇에게 `/help`, `/go [역이름]`, `/stop` 과 같이 요청할 수 있음.
  - 이후 `go` 명령이 들어오면 실시간 지하철 도착정보 api를 호출, 분/초 단위 도착정보 갱신하는 로직 추가하면 될 듯.
## 질문
- 보통 자주 사용하는 상수나 구조체 같은 것들을 한 파일에 몰아넣는데.. "the most rustonic way" 가 궁금합니다ㅋㅋㅋ 지금처럼 `artifacts.rs` 이런거 만들어서 `ClientResponse` 이런애들 몰아놔도 괜찮나요~?
- 같은 맥락에서.. 39 라인의 `enum Command` 얘도 `artifacts.rs`로 넘기고 싶은데 view range 관련 에러가 발생합니다ㅠ 아 에러메시지 캡처하는 걸 까먹었네요..
- 최종적으로는 `telbot.rs`, `subway.rs`, `main.rs` 이렇게 세 개 파일로만 구성하던가, 아니면 +  `artifacts.rs` 같은걸 유지하던가 하면 어떨까 싶습니다. 이때 각 모듈을 가져오는 과정에서 퍼블릭/프라이빗 이런 범위가 중요한 거 같은데 국룰이 뭔지 궁금합니다 히힣