### PR TITLE
Add main logic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,6 @@ extern crate tokio;
 use teloxide::prelude::*;
 
 mod seoul;
-use seoul::{get_client_config, get_public_api_key, make_url, ClientResponse};
-
 mod telebot;
 use telebot::{answer_from_bot, Command};
 
@@ -12,15 +10,6 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // read api-key and make request url
-    let api_key = get_public_api_key("src/public_subway_api_key.yml");
-    let client_config: seoul::ClientConfig = get_client_config("src/client_config.yaml");
-
-    let url = make_url(api_key, client_config, "동천".to_string());
-    let response = reqwest::get(url).await?.json::<ClientResponse>().await?;
-
-    println!("{:?}", response);
-
     pretty_env_logger::init();
     log::info!("Starting command bot...");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
-use std::collections::HashMap;
-use std::fs::File;
-
 use serde_yaml::{self};
-use teloxide::{prelude::*, utils::command::BotCommands};
-use urlencoding::encode;
 extern crate tokio;
+use teloxide::prelude::*;
 
-mod artifacts;
-use artifacts::{ClientConfig, ClientResponse};
+mod seoul;
+use seoul::{get_client_config, get_public_api_key, make_url, ClientResponse};
+
+mod telebot;
+use telebot::{answer_from_bot, Command};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -15,7 +14,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>
 async fn main() -> Result<()> {
     // read api-key and make request url
     let api_key = get_public_api_key("src/public_subway_api_key.yml");
-    let client_config: artifacts::ClientConfig = get_client_config("src/client_config.yaml");
+    let client_config: seoul::ClientConfig = get_client_config("src/client_config.yaml");
 
     let url = make_url(api_key, client_config, "동천".to_string());
     let response = reqwest::get(url).await?.json::<ClientResponse>().await?;
@@ -29,71 +28,4 @@ async fn main() -> Result<()> {
 
     Command::repl(bot, answer_from_bot).await;
     return Ok(());
-}
-
-#[derive(BotCommands, Clone)]
-#[command(
-    rename_rule = "lowercase",
-    description = "These commands are supported:"
-)]
-enum Command {
-    #[command(description = "display this text.")]
-    Help,
-    #[command(description = "start to watch")]
-    Go(String),
-    #[command(description = "stop to watch ")]
-    Stop,
-}
-
-async fn answer_from_bot(bot: Bot, msg: Message, cmd: Command) -> ResponseResult<()> {
-    match cmd {
-        Command::Help => {
-            bot.send_message(msg.chat.id, Command::descriptions().to_string())
-                .await?
-        }
-
-        Command::Go(station) => {
-            bot.send_message(msg.chat.id, format!("watching {station}.."))
-                .await?
-        }
-        Command::Stop => {
-            bot.send_message(msg.chat.id, format!("stop to watching."))
-                .await?
-        }
-    };
-
-    Ok(())
-}
-
-fn get_public_api_key(api_key_path: &str) -> String {
-    let f = File::open(api_key_path).expect("Could not open file.");
-    let api_key: HashMap<String, String> =
-        serde_yaml::from_reader(f).expect("Could not read values.");
-    return api_key["API_KEY"].to_string();
-}
-
-fn get_client_config(clien_config_path: &str) -> ClientConfig {
-    let f = File::open(clien_config_path).expect("Could not open file.");
-    let client_config: ClientConfig = serde_yaml::from_reader(f).expect("Could hot read values");
-    return client_config;
-}
-
-fn make_url(
-    api_key: String,
-    client_config: ClientConfig,
-    station_name: String, //station name is KOREAN. have to be converted to ASCII and encoded UTF-8.
-) -> String {
-    let encodec_station_name = encode(&station_name);
-    let full_url = format!(
-        "{}/{}/{}/{}/{}/{}/{}",
-        client_config.seoul_url,
-        api_key,
-        client_config.file_type,
-        client_config.service_name,
-        client_config.start_index,
-        client_config.end_index,
-        encodec_station_name
-    );
-
-    return full_url;
 }

--- a/src/seoul.rs
+++ b/src/seoul.rs
@@ -48,7 +48,7 @@ pub struct ServerMessage {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct ClientResponse {
+pub struct SeoulResponse {
     errorMessage: ServerMessage,
     realtimeArrivalList: Vec<RealTimeArrival>,
 }
@@ -86,7 +86,7 @@ pub fn make_url(
     return full_url;
 }
 
-pub fn get_arrival_time_in_second(response: ClientResponse) -> String {
+pub fn get_arrival_time_in_second(response: SeoulResponse) -> String {
     let mut arrival_msg = String::new();
 
     for element in response.realtimeArrivalList {

--- a/src/seoul.rs
+++ b/src/seoul.rs
@@ -85,3 +85,19 @@ pub fn make_url(
 
     return full_url;
 }
+
+pub fn get_arrival_time_in_second(response: ClientResponse) -> String {
+    let mut arrival_msg = String::new();
+
+    for element in response.realtimeArrivalList {
+        arrival_msg.push_str(
+            format!(
+                "{}: {} sec.\n",
+                element.trainLineNm.unwrap(),
+                element.barvlDt.unwrap(),
+            )
+            .as_str(),
+        );
+    }
+    return arrival_msg;
+}

--- a/src/seoul.rs
+++ b/src/seoul.rs
@@ -1,4 +1,8 @@
+use std::collections::HashMap;
+use std::fs::File;
+
 use serde::{Deserialize, Serialize};
+use urlencoding::encode;
 
 #[derive(Serialize, Deserialize)]
 pub struct ClientConfig {
@@ -47,4 +51,37 @@ pub struct ServerMessage {
 pub struct ClientResponse {
     errorMessage: ServerMessage,
     realtimeArrivalList: Vec<RealTimeArrival>,
+}
+
+pub fn get_public_api_key(api_key_path: &str) -> String {
+    let f = File::open(api_key_path).expect("Could not open file.");
+    let api_key: HashMap<String, String> =
+        serde_yaml::from_reader(f).expect("Could not read values.");
+    return api_key["API_KEY"].to_string();
+}
+
+pub fn get_client_config(clien_config_path: &str) -> ClientConfig {
+    let f = File::open(clien_config_path).expect("Could not open file.");
+    let client_config: ClientConfig = serde_yaml::from_reader(f).expect("Could hot read values");
+    return client_config;
+}
+
+pub fn make_url(
+    api_key: String,
+    client_config: ClientConfig,
+    station_name: String, //station name is KOREAN. have to be converted to ASCII and encoded UTF-8.
+) -> String {
+    let encodec_station_name = encode(&station_name);
+    let full_url = format!(
+        "{}/{}/{}/{}/{}/{}/{}",
+        client_config.seoul_url,
+        api_key,
+        client_config.file_type,
+        client_config.service_name,
+        client_config.start_index,
+        client_config.end_index,
+        encodec_station_name
+    );
+
+    return full_url;
 }

--- a/src/telebot.rs
+++ b/src/telebot.rs
@@ -1,0 +1,35 @@
+use teloxide::{prelude::*, utils::command::BotCommands};
+
+#[derive(BotCommands, Clone)]
+#[command(
+    rename_rule = "lowercase",
+    description = "These commands are supported:"
+)]
+pub enum Command {
+    #[command(description = "display this text.")]
+    Help,
+    #[command(description = "start to watch")]
+    Go(String),
+    #[command(description = "stop to watch ")]
+    Stop,
+}
+
+pub async fn answer_from_bot(bot: Bot, msg: Message, cmd: Command) -> ResponseResult<()> {
+    match cmd {
+        Command::Help => {
+            bot.send_message(msg.chat.id, Command::descriptions().to_string())
+                .await?
+        }
+
+        Command::Go(station) => {
+            bot.send_message(msg.chat.id, format!("watching {station}.."))
+                .await?
+        }
+        Command::Stop => {
+            bot.send_message(msg.chat.id, format!("stop to watching."))
+                .await?
+        }
+    };
+
+    Ok(())
+}

--- a/src/telebot.rs
+++ b/src/telebot.rs
@@ -2,7 +2,7 @@ use teloxide::{prelude::*, utils::command::BotCommands};
 
 use crate::seoul::{
     get_arrival_time_in_second, get_client_config, get_public_api_key, make_url, ClientConfig,
-    ClientResponse,
+    SeoulResponse,
 };
 
 #[derive(BotCommands, Clone)]
@@ -32,8 +32,7 @@ pub async fn answer_from_bot(bot: Bot, msg: Message, cmd: Command) -> ResponseRe
 
         Command::Go(station) => {
             let url: String = make_url(api_key, client_config, station.trim().to_string());
-            let response: ClientResponse =
-                reqwest::get(url).await?.json::<ClientResponse>().await?;
+            let response: SeoulResponse = reqwest::get(url).await?.json::<SeoulResponse>().await?;
             let arrival_msg: String = get_arrival_time_in_second(response);
 
             bot.send_message(msg.chat.id, format!("{arrival_msg}"))

--- a/src/telebot.rs
+++ b/src/telebot.rs
@@ -31,9 +31,10 @@ pub async fn answer_from_bot(bot: Bot, msg: Message, cmd: Command) -> ResponseRe
         }
 
         Command::Go(station) => {
-            let url: String = make_url(api_key, client_config, station);
-            let response = reqwest::get(url).await?.json::<ClientResponse>().await?;
-            let arrival_msg = get_arrival_time_in_second(response);
+            let url: String = make_url(api_key, client_config, station.trim().to_string());
+            let response: ClientResponse =
+                reqwest::get(url).await?.json::<ClientResponse>().await?;
+            let arrival_msg: String = get_arrival_time_in_second(response);
 
             bot.send_message(msg.chat.id, format!("{arrival_msg}"))
                 .await?


### PR DESCRIPTION
## 작업내역
- 도착정보 초단위로 출력(1회) 로직 추가
- 파일 구조 변경(`main.rs`,`telebot.rs`,`seoul.rs`
## 남은작업
- 없는 역이름 들어올 때 예외처리
- 60초 넘어가면 분/초 단위로 출력
- 0 sec 반환 좀 더 이쁘게...? (지금 들어오는 지하철이 없습니다..라던가)
## 질문
- 지금 구조상으로는 `telebot.rs`안에 있는 `answer_from_bot`함수가 사용자 입력을 받으면 seoul api를 호출하는 형태입니다.
  - 이걸 callback 형태로 바꿀 수 있을까요~?
  - `telebot.rs` 34~36라인을 하나의 함수로 만든다고 생각하고, match문에서 GO(Help/Go/Stop Command 中)로 빠질때 그 함수를 callback하는 형태
- 에러처리 관련
  - `reqwest::get()`의 반환 타입으로 `SeoulResponse`를 받고 있습니다(`telebot.rs` 35 라인).
  - `SeoulResponse.errorMessage`가 seoul api의 서버 상태 메시지를 받아오도록 하는게 의도였는데.. 이게 위 함수 `reqwest::get()`의 요청에 대한 데이터가 없는 경우(`INFO-200` 코드로 반환, [API spec](https://data.seoul.go.kr/dataList/OA-12764/F/1/datasetView.do))에는 `SeoulResponse.realtimeArrivalList`가 채워지지 않아서 걍 에러로 빠지는 것 같읍니다..
  - 프로그램이 죽지는 않는데, 예외처리가 좀 더 깔끔했으면 좋겠어서요 히힣ㅎ 무슨 방법이 있을까요..?
    <img width="629" alt="image" src="https://user-images.githubusercontent.com/126950833/233777553-d6e50069-a3a2-455d-9a4e-2c45e2d85a7f.png">

## 스샷
<img width="380" alt="image" src="https://user-images.githubusercontent.com/126950833/233754121-8deca251-75cf-45c8-ae66-7d3c0093a685.png">

