### PR TITLE
다이얼로그로 변경

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,31 @@
 use serde_yaml::{self};
 extern crate tokio;
-use teloxide::prelude::*;
+use teloxide::{dispatching::dialogue::InMemStorage, prelude::*};
 
 mod seoul;
+use seoul::{get_client_config, get_public_api_key, ClientConfig};
 mod telebot;
-use telebot::{answer_from_bot, Command};
+use telebot::{receive_station, start, State};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
     pretty_env_logger::init();
     log::info!("Starting command bot...");
 
     let bot = Bot::from_env();
 
-    Command::repl(bot, answer_from_bot).await;
-    return Ok(());
+    Dispatcher::builder(
+        bot,
+        Update::filter_message()
+            .enter_dialogue::<Message, InMemStorage<State>, State>()
+            .branch(dptree::case![State::Start].endpoint(start))
+            .branch(dptree::case![State::ReceiveStation].endpoint(receive_station)),
+    )
+    .dependencies(dptree::deps![InMemStorage::<State>::new()])
+    .enable_ctrlc_handler()
+    .build()
+    .dispatch()
+    .await;
 }

--- a/src/seoul.rs
+++ b/src/seoul.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use serde::{Deserialize, Serialize};
 use urlencoding::encode;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ClientConfig {
     pub seoul_url: String,
     pub file_type: String,

--- a/src/seoul.rs
+++ b/src/seoul.rs
@@ -60,8 +60,8 @@ pub fn get_public_api_key(api_key_path: &str) -> String {
     return api_key["API_KEY"].to_string();
 }
 
-pub fn get_client_config(clien_config_path: &str) -> ClientConfig {
-    let f = File::open(clien_config_path).expect("Could not open file.");
+pub fn get_client_config(client_config_path: &str) -> ClientConfig {
+    let f = File::open(client_config_path).expect("Could not open file.");
     let client_config: ClientConfig = serde_yaml::from_reader(f).expect("Could hot read values");
     return client_config;
 }


### PR DESCRIPTION
## 작업내역
- 기존에 `Command`를 이용해서 제어하던 것을 `Dialogue`로 변경
- 불편했던 `/go [역이름]`  대신 `역이름`으로 리퀘스트 가능
## 아직 모르겠는거 + 새로운 질문
- call back function (저번 pr 그거ㅠ)
- `main.rs` 19~26 라인에서 텔레봇 빌드하는데, 이때 `receive_station` 함수의 파라미터로 `api_key` `client_config`를 전달하려면 어케 해야될까요.. 이거 teloxide 다큐먼트 뒤져봐도 잘 안나오더라고여 엉뚱한데를 보고있었는지ㅠㅋㅋㅋㅋ
## 실행화면
![image](https://user-images.githubusercontent.com/126950833/234721454-6cabbc86-752a-448b-86d1-c3cfc9ba8da1.png)

close #5 